### PR TITLE
Add jmap_dumper options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,36 @@
 JSON based format for storing UObject reflection data, vtable layouts, version information, among other things extracted from compiled Unreal Engine binaries.
 
 ## [jmap_dumper](jmap_dumper)
+```
+Usage: jmap_dumper.exe [OPTIONS] <--pid <PID>|--minidump <MINIDUMP>|--jmap <JMAP>> <OUTPUT>
 
+Arguments:
+  <OUTPUT>  Output dump .jmap path
+
+Options:
+  -p, --pid <PID>                  Dump from process ID
+  -m, --minidump <MINIDUMP>        Dump from minidump
+  -j, --jmap <JMAP>                Use existing .jmap dump
+  -s, --struct-info <STRUCT_INFO>  Struct layout info .json (from pdb_dumper)
+  -h, --help                       Print help
+  -V, --version                    Print version
+```
+
+Memory Dump (.dmp) to .usmap:
+```
+PS ..\jmap_dumper-x86_64-pc-windows-msvc> .\jmap_dumper.exe -m "D:\VoyagerGame\STVoyager-Win64-Shipping-v2.DMP" "D:\VoyagerGame\VoyagerMappings_v2.usmap"
+Resolution { guobject_array: GUObjectArray(7FF6A9D38590), fname_pool: FNamePool(7FF6A9F4A940), engine_version: EngineVersion(5.6), opt: OptResolution { build: Ok(BuildChangeList("UE5-CL-0")) } }
+Success! Output written to D:\VoyagerGame\VoyagerMappings_v2.usmap
+```
+In case of message "Error: Resolution: EngineVersion: expected at least one value", set an environment variable for patternsleuth library:
+
+`$env:PATTERNSLEUTH_RES_EngineVersion="ver"` e.g. `$env:PATTERNSLEUTH_RES_EngineVersion="5.6"`
+
+In case of message like "Error: Resolution: FNamePool: found 2 unique values [7FF6DB379E00, 7FFDB90C6140]", set an environment variable for patternsleuth library:
+
+`$env:PATTERNSLEUTH_RES_FNamePool=0x<one of the found FNamePool values>` e.g. `$env:PATTERNSLEUTH_RES_FNamePool=0x7FF6DB379E00`
+
+## Legacy Commands
 Dump from running process:
 ```console
 cargo run --release -- --pid 12345 output.jmap
@@ -18,14 +47,6 @@ Or output to .usmap:
 ```console
 cargo run --release -- --minidump FSD-Win64-Shipping.DMP output.usmap
 ```
-
-In case of message "Error: Resolution: EngineVersion: expected at least one value", set an environment variable for patternsleuth library:
-
-`$env:PATTERNSLEUTH_RES_EngineVersion="ver"` e.g. `$env:PATTERNSLEUTH_RES_EngineVersion="5.6"`
-
-In case of message like "Error: Resolution: FNamePool: found 2 unique values [7FF6DB379E00, 7FFDB90C6140]", set an environment variable for patternsleuth library:
-
-`$env:PATTERNSLEUTH_RES_FNamePool=0x<one of the found FNamePool values>` e.g. `$env:PATTERNSLEUTH_RES_FNamePool=0x7FF6DB379E00`
 
 ## output
 The output JSON is a superset of .usmap and contains enough information to fully reconstruct a matching project in the Unreal Engine editor.


### PR DESCRIPTION
Dumping actual jmap_dumper help screen and sample .dmp to .usmap generation.

This will help anyone looking to use the precompiled version, as the old instructions date back to when the code had to be compiled.